### PR TITLE
Hotfix/1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Para la correcta ejecución de las funcionalidades del frontend, la siguiente ru
 
 Alternativamente puede desplegar usando contenedores de docker. Primero construya la imagen:
 
-`docker build -t visor-i2d:1.1.0 .`
+`docker build -t visor-i2d:1.1.1 .`
 
 Detenga el contenedor:
 
@@ -265,7 +265,7 @@ Borre el contenedor antiguo:
 
 Después levante el contenedor:
 
-`docker run --name=visor_i2d --network=i2d.net -p 3000:80 -d visor-i2d:1.1.0`
+`docker run --name=visor_i2d --network=i2d.net -p 3000:80 -d visor-i2d:1.1.1`
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "i2d",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "",
     "main": "index.html",
     "repository": {

--- a/src/components/pageComponent/side-options/tab-charts/create-chart/exportReport/export-modal.js
+++ b/src/components/pageComponent/side-options/tab-charts/create-chart/exportReport/export-modal.js
@@ -106,7 +106,7 @@ $(document).on('submit', 'form#formSolicitante', function (e) {
     // alert('Su información fue almacenada')
     $('#userFormModal').remove();
 
-    if (type == 'downloadPDF' || type == 'downloadAll') {
+    if (type == 'downloadPDF') {
       // create and export pdf
       savePDF();
     }

--- a/src/components/pageComponent/side-options/tab-charts/create-chart/exportReport/export-pdf.js
+++ b/src/components/pageComponent/side-options/tab-charts/create-chart/exportReport/export-pdf.js
@@ -1,5 +1,6 @@
 import logoi2d from '../../../../../../assets/img/logo-humboldt-v2.png'
 import footeri2d from '../../../../../../assets/img/footer.png'
+import { PDF_ASSET_BASE_URL } from '../../../../../server/url'
 
 import pdfMake from "pdfmake/build/pdfmake.min";
 import pdfFonts from "pdfmake/build/vfs_fonts";
@@ -29,10 +30,10 @@ function imageToDataURL(imagePath) {
         if (!imagePath.startsWith('http://') && !imagePath.startsWith('https://')) {
             // For bundled assets, the path is already correct from the import
             // Just ensure it's an absolute URL
-            if (!imagePath.startsWith('/')) {
+            if (!imagePath.startsWith('/') && !PDF_ASSET_BASE_URL.endsWith('/')) {
                 fullImagePath = '/' + imagePath;
             }
-            fullImagePath = window.location.origin + fullImagePath;
+            fullImagePath = PDF_ASSET_BASE_URL + fullImagePath;
         }
 
         const alternativePaths = [];

--- a/src/components/server/url.js
+++ b/src/components/server/url.js
@@ -22,4 +22,4 @@ export const ESRI_WORLD_IMAGERY_URL = process.env.ESRI_WORLD_IMAGERY_URL || 'htt
 
 // Public base URL used to resolve asset URLs in generated PDFs
 // Example: https://i2d.humboldt.org.co/visor-I2D/
-export const PDF_ASSET_BASE_URL = process.env.PDF_ASSET_BASE_URL || '';
+export const PDF_ASSET_BASE_URL = process.env.PDF_ASSET_BASE_URL || window.location.origin;


### PR DESCRIPTION
## 🛠️ Changes
Downloads the PDFs using the env variable PDF_ASSET_BASE_URL

## 📝 Associated issues
Resolves LIB-519

## 🤔 Considerations
If the variable is left empty, the download PDF function will use the current hostname and port as URL.

## ✅ Checks
The README and package.json versions were bumped to 1.1.1