### PR TITLE
Fix click detection for point layers

### DIFF
--- a/src/components/mapComponent/controls/layersSelect.js
+++ b/src/components/mapComponent/controls/layersSelect.js
@@ -66,7 +66,6 @@ export var layerSelection = (coordinate) => {
         }
     } catch (err) {
         console.error('An error occured selecting the layer:', error);
-        throw error;
     }
 }
 

--- a/src/components/mapComponent/controls/layersSelect.js
+++ b/src/components/mapComponent/controls/layersSelect.js
@@ -29,39 +29,44 @@ const getAllLayers = () => {
 
 // get wms layers if turn on
 export var layerSelection = (coordinate) => {
-    const AllLayerss = getAllLayers();
+    try {
+        const AllLayerss = getAllLayers();
 
-    // select the wms layers
-    $('#contenedorg').html('');
-    $('#nav-layers').attr("style", "display:none");
-    // wms layers
-    let varMpio = null;
+        // select the wms layers
+        $('#contenedorg').html('');
+        $('#nav-layers').attr("style", "display:none");
+        // wms layers
+        let varMpio = null;
 
-    for (var i = 1; i < AllLayerss.length; i++) {
-        // if turn on
-        if (i == 1 && AllLayerss[i].values_.visible === true) {
-            varMpio = true
-            // get mupio features data
-            wmsGetProps(AllLayerss, 1, coordinate, Selection);
-            wmsGetProps(AllLayerss, 0, coordinate, featDpto);
-            function featDpto(features, i) { dptoFeature = features[0]; SelectionLayers(features, i) }
+        for (var i = 1; i < AllLayerss.length; i++) {
+            // if turn on
+            if (i == 1 && AllLayerss[i].values_.visible === true) {
+                varMpio = true
+                // get mupio features data
+                wmsGetProps(AllLayerss, 1, coordinate, Selection);
+                wmsGetProps(AllLayerss, 0, coordinate, featDpto);
+                function featDpto(features, i) { dptoFeature = features[0]; SelectionLayers(features, i) }
 
-        } else if (i == 1 && !varMpio && AllLayerss[i].values_.visible === false) {
-            // get dpto features data
-            wmsGetProps(AllLayerss, 0, coordinate, Selection);
+            } else if (i == 1 && !varMpio && AllLayerss[i].values_.visible === false) {
+                // get dpto features data
+                wmsGetProps(AllLayerss, 0, coordinate, Selection);
 
-        } else if (AllLayerss[i].values_.visible === true) {
-            // get features data
-            wmsGetProps(AllLayerss, i, coordinate, Selection);
-        } else if (AllLayerss[i].values_.visible === false) {
-            // mupios is not active
-            $('#layers-data-tab').tab('show');
-            $('#nav-layers').attr("style", "display:block");
-            if (i == 1 && i == 0) {
-                highlightStadisticsRemove();
-                $('#nav-chart').attr("style", "display:none");
+            } else if (AllLayerss[i].values_.visible === true) {
+                // get features data
+                wmsGetProps(AllLayerss, i, coordinate, Selection);
+            } else if (AllLayerss[i].values_.visible === false) {
+                // mupios is not active
+                $('#layers-data-tab').tab('show');
+                $('#nav-layers').attr("style", "display:block");
+                if (i == 1 && i == 0) {
+                    highlightStadisticsRemove();
+                    $('#nav-chart').attr("style", "display:none");
+                }
             }
         }
+    } catch (err) {
+        console.error('An error occured selecting the layer:', error);
+        throw error;
     }
 }
 

--- a/src/components/mapComponent/controls/layersSelect.js
+++ b/src/components/mapComponent/controls/layersSelect.js
@@ -29,43 +29,39 @@ const getAllLayers = () => {
 
 // get wms layers if turn on
 export var layerSelection = (coordinate) => {
-    try {
-        const AllLayerss = getAllLayers();
+    const AllLayerss = getAllLayers();
 
-        // select the wms layers
-        $('#contenedorg').html('');
-        $('#nav-layers').attr("style", "display:none");
-        // wms layers
-        let varMpio = null;
+    // select the wms layers
+    $('#contenedorg').html('');
+    $('#nav-layers').attr("style", "display:none");
+    // wms layers
+    let varMpio = null;
 
-        for (var i = 1; i < AllLayerss.length; i++) {
-            // if turn on
-            if (i == 1 && AllLayerss[i].values_.visible === true) {
-                varMpio = true
-                // get mupio features data
-                wmsGetProps(AllLayerss, 1, coordinate, Selection);
-                wmsGetProps(AllLayerss, 0, coordinate, featDpto);
-                function featDpto(features, i) { dptoFeature = features[0]; SelectionLayers(features, i) }
+    for (var i = 1; i < AllLayerss.length; i++) {
+        // if turn on
+        if (i == 1 && AllLayerss[i].values_.visible === true) {
+            varMpio = true
+            // get mupio features data
+            wmsGetProps(AllLayerss, 1, coordinate, Selection);
+            wmsGetProps(AllLayerss, 0, coordinate, featDpto);
+            function featDpto(features, i) { dptoFeature = features[0]; SelectionLayers(features, i) }
 
-            } else if (i == 1 && !varMpio && AllLayerss[i].values_.visible === false) {
-                // get dpto features data
-                wmsGetProps(AllLayerss, 0, coordinate, Selection);
+        } else if (i == 1 && !varMpio && AllLayerss[i].values_.visible === false) {
+            // get dpto features data
+            wmsGetProps(AllLayerss, 0, coordinate, Selection);
 
-            } else if (AllLayerss[i].values_.visible === true) {
-                // get features data
-                wmsGetProps(AllLayerss, i, coordinate, Selection);
-            } else if (AllLayerss[i].values_.visible === false) {
-                // mupios is not active
-                $('#layers-data-tab').tab('show');
-                $('#nav-layers').attr("style", "display:block");
-                if (i == 1 && i == 0) {
-                    highlightStadisticsRemove();
-                    $('#nav-chart').attr("style", "display:none");
-                }
+        } else if (AllLayerss[i].values_.visible === true) {
+            // get features data
+            wmsGetProps(AllLayerss, i, coordinate, Selection);
+        } else if (AllLayerss[i].values_.visible === false) {
+            // mupios is not active
+            $('#layers-data-tab').tab('show');
+            $('#nav-layers').attr("style", "display:block");
+            if (i == 1 && i == 0) {
+                highlightStadisticsRemove();
+                $('#nav-chart').attr("style", "display:none");
             }
         }
-    } catch (err) {
-        console.error('An error occured selecting the layer:', error);
     }
 }
 

--- a/src/components/server/geoserver/wmsGetProps.js
+++ b/src/components/server/geoserver/wmsGetProps.js
@@ -12,9 +12,16 @@ import {getProjection} from '../../mapComponent/map'
 import {feats} from '../../mapComponent/layers'
 import {fitView,getResolution} from '../../mapComponent/map'
 
-
+const circleLayers = ['red_viveros', 'procesos_gobernanza'];
 var format = [], wmsSource = [];
 
+function getDynamicBuffer(resolution) {
+    // scaleDenominator = resolution x 3571 (OGC standar (1/0.00028))
+    if (resolution > 1900) return 4;
+    if (resolution > 560) return 7;
+    if (resolution > 280) return 9;
+    return 10;
+}
 // select wms layers if turn on
 export var wmsGetProps=(AllLayers,i,coordinate,Selection)=>{
     var featureType = AllLayers[i].values_.source.params_.LAYERS;
@@ -31,12 +38,22 @@ export var wmsGetProps=(AllLayers,i,coordinate,Selection)=>{
     // if is a point or if not 
     //let resolution=layer=='procesos_gobernanza'?getResolution(): 1;
     let resolution=layer==layer?getResolution(): 1;
-    if (resolution > 200){
-        resolution=200;
+
+    const params = {
+        'INFO_FORMAT': infoFormat,
     }
+
+    if (circleLayers.includes(layer)) {
+        params['BUFFER'] = getDynamicBuffer(resolution);
+    } else {
+        if (resolution > 200){
+            resolution=200;
+        }
+    }
+    
     var url = wmsSource[i].getFeatureInfoUrl(
         coordinate, resolution, getProjection(),
-        {'INFO_FORMAT': infoFormat}
+        params
     );
     $.ajax({
         url: url,

--- a/src/components/server/geoserver/wmsGetProps.js
+++ b/src/components/server/geoserver/wmsGetProps.js
@@ -14,7 +14,6 @@ import {fitView,getResolution} from '../../mapComponent/map'
 
 const circleLayers = ['red_viveros', 'procesos_gobernanza'];
 var format = [], wmsSource = [];
-
 function getDynamicBuffer(resolution) {
     // scaleDenominator = resolution x 3571 (OGC standar (1/0.00028))
     if (resolution > 1900) return 4;
@@ -22,10 +21,20 @@ function getDynamicBuffer(resolution) {
     if (resolution > 280) return 9;
     return 10;
 }
+
+async function hasPointPropertyType(layerName) {
+    const url = `${GEOSERVER_URL}wfs?SERVICE=WFS&REQUEST=DescribeFeatureType&TYPENAME=${layerName}`;
+    const response = await fetch(url);
+    const text = await response.text();
+    if (text.includes('PointPropertyType')) return true;
+    return false;
+}
+
 // select wms layers if turn on
-export var wmsGetProps=(AllLayers,i,coordinate,Selection)=>{
+export var wmsGetProps= async (AllLayers,i,coordinate,Selection)=>{
     var featureType = AllLayers[i].values_.source.params_.LAYERS;
     var layer=featureType.split(':')[1]
+    var layerName = AllLayers[i].values_.geoserverName
     format[i] = new WFS({featureNS: featureNS, featureType: layer});
     wmsSource[i] = new TileWMS({
         url: GEOSERVER_URL+'ows?',
@@ -38,12 +47,11 @@ export var wmsGetProps=(AllLayers,i,coordinate,Selection)=>{
     // if is a point or if not 
     //let resolution=layer=='procesos_gobernanza'?getResolution(): 1;
     let resolution=layer==layer?getResolution(): 1;
-
     const params = {
         'INFO_FORMAT': infoFormat,
     }
 
-    if (circleLayers.includes(layer)) {
+    if (await hasPointPropertyType(layerName) === true) {
         params['BUFFER'] = getDynamicBuffer(resolution);
     } else {
         if (resolution > 200){

--- a/src/components/server/geoserver/wmsGetProps.js
+++ b/src/components/server/geoserver/wmsGetProps.js
@@ -12,9 +12,8 @@ import {getProjection} from '../../mapComponent/map'
 import {feats} from '../../mapComponent/layers'
 import {fitView,getResolution} from '../../mapComponent/map'
 
-const circleLayers = ['red_viveros', 'procesos_gobernanza'];
 var format = [], wmsSource = [];
-function getDynamicBuffer(resolution) {
+var getDynamicBuffer = (resolution) => {
     // scaleDenominator = resolution x 3571 (OGC standar (1/0.00028))
     if (resolution > 1900) return 4;
     if (resolution > 560) return 7;
@@ -22,7 +21,7 @@ function getDynamicBuffer(resolution) {
     return 10;
 }
 
-async function hasPointPropertyType(layerName) {
+var hasPointPropertyType = async (layerName) => {
     const url = `${GEOSERVER_URL}wfs?SERVICE=WFS&REQUEST=DescribeFeatureType&TYPENAME=${layerName}`;
     const response = await fetch(url);
     const text = await response.text();
@@ -31,7 +30,7 @@ async function hasPointPropertyType(layerName) {
 }
 
 // select wms layers if turn on
-export var wmsGetProps= async (AllLayers,i,coordinate,Selection)=>{
+export var wmsGetProps= (AllLayers,i,coordinate,Selection)=>{
     var featureType = AllLayers[i].values_.source.params_.LAYERS;
     var layer=featureType.split(':')[1]
     var layerName = AllLayers[i].values_.geoserverName
@@ -44,20 +43,21 @@ export var wmsGetProps= async (AllLayers,i,coordinate,Selection)=>{
         },
         serverType: 'geoserver'
     });
-    // if is a point or if not 
-    //let resolution=layer=='procesos_gobernanza'?getResolution(): 1;
+    
     let resolution=layer==layer?getResolution(): 1;
     const params = {
         'INFO_FORMAT': infoFormat,
     }
 
-    if (await hasPointPropertyType(layerName) === true) {
-        params['BUFFER'] = getDynamicBuffer(resolution);
-    } else {
-        if (resolution > 200){
-            resolution=200;
+    hasPointPropertyType(layerName).then(result => {
+        if (result) {
+            params['BUFFER'] = getDynamicBuffer(resolution);
+        } else {
+            if (resolution > 200){
+                resolution=200;
+            }
         }
-    }
+    })
     
     var url = wmsSource[i].getFeatureInfoUrl(
         coordinate, resolution, getProjection(),
@@ -78,11 +78,7 @@ export var wmsGetProps= async (AllLayers,i,coordinate,Selection)=>{
                 }
 
                 Selection(features,i);
-            }else{
-                console.log('sin features')
             }
-
-            // console.log(sele,data,sel);
         }
     });
 }

--- a/src/components/server/geoserver/wmsGetProps.js
+++ b/src/components/server/geoserver/wmsGetProps.js
@@ -44,7 +44,7 @@ export var wmsGetProps= (AllLayers,i,coordinate,Selection)=>{
         serverType: 'geoserver'
     });
     
-    let resolution=layer==layer?getResolution(): 1;
+    let resolution = getResolution() ?? 1;
     const params = {
         'INFO_FORMAT': infoFormat,
     }


### PR DESCRIPTION
## 🛠️ Changes
Se modificó el área de pixels que se toman con cada click para que concuerden mejor con el tamaño del target. 
Se implementó DescribeFeatureType para saber si la capa seleccionada usa puntos como marcardores y así asignar el buffer dinámicamente

## 📝 Associated issues
LIB-557

## 🤔 Considerations
También se hicieron modificaciones en los estilos del geoserver, se modificó la propiedad `Size` en el estilo viveros2:
```
<Size>
 <ogc:Function name="Interpolate">
   <ogc:Function name="env">
     <ogc:Literal>wms_scale_denominator</ogc:Literal>
   </ogc:Function>
   <!-- Municipality -->
   <ogc:Literal>800000</ogc:Literal>
   <ogc:Literal>30</ogc:Literal>
   <!-- Department -->
   <ogc:Literal>1000000</ogc:Literal>
   <ogc:Literal>20</ogc:Literal>
   <!-- Regional -->
   <ogc:Literal>2000000</ogc:Literal>
   <ogc:Literal>15</ogc:Literal>
   <!-- No zoom -->
   <ogc:Literal>7000000</ogc:Literal>
   <ogc:Literal>10</ogc:Literal>
 </ogc:Function>
</Size>
```

Y en el estilo de gobernanza (en las 4 subcategorías):
```
<se:Size>
 <ogc:Function name="Interpolate">
   <ogc:Function name="env">
     <ogc:Literal>wms_scale_denominator</ogc:Literal>
   </ogc:Function>
   <!-- Municipality -->
   <ogc:Literal>800000</ogc:Literal>
   <ogc:Literal>30</ogc:Literal>
   <!-- Department -->
   <ogc:Literal>1000000</ogc:Literal>
   <ogc:Literal>20</ogc:Literal>
   <!-- Regional -->
   <ogc:Literal>2000000</ogc:Literal>
   <ogc:Literal>15</ogc:Literal>
   <!-- No zoom -->
   <ogc:Literal>7000000</ogc:Literal>
   <ogc:Literal>10</ogc:Literal>
 </ogc:Function>
</se:Size>
```
Además en el estilo de gobernanza se agregó manualmente la imagen de la leyenda.
<img width="214" height="100" alt="geoserver-Gobernanza" src="https://github.com/user-attachments/assets/a806609b-bc86-47cf-a7d5-976e2ff0d31b" />
 