### PR TITLE
lserrano/LIB-582: Fix layer's links to BioCultural

### DIFF
--- a/src/components/mapComponent/controls/hierarchical-tree-layers.js
+++ b/src/components/mapComponent/controls/hierarchical-tree-layers.js
@@ -1,10 +1,10 @@
 import $ from "jquery";
 import { closeTutorialOnStep4 } from "../../tutorialComponent/tutorial";
+import {GEOSERVER_URL,GEONETWORK_URL,DATAVERSE_URL} from '../../server/url'
 
 // Get proyecto from URL params instead of importing from layers
 const urlParams = new URLSearchParams(window.location.search);
 const proyecto = urlParams.get('proyecto') || 'general';
-const GEOSERVER_URL = process.env.GEOSERVER_URL || 'https://geoservicios.humboldt.org.co/geoserver/';
 
 /**
  * Fit map view to layer extent with animation
@@ -628,13 +628,15 @@ function renderLayer(layerData, parentElement, layerGroup) {
   formCheck.appendChild(label);
 
   // Add metadata link if available
-  if (layerData.metadata_id) {
+  let metadata = layerData.metadata_id;
+  if (metadata) {
+    let repositorio = metadata.length <= 6 ? DATAVERSE_URL : GEONETWORK_URL;
     const metadataLink = document.createElement("div");
     metadataLink.innerHTML = '<i class="fas fa-link"></i>';
     metadataLink.className = "card-link float-right";
     metadataLink.setAttribute(
       "onclick",
-      `window.open("https://geonetwork.humboldt.org.co/geonetwork/srv/spa/catalog.search#/metadata/${layerData.metadata_id}")`
+      `window.open("${repositorio}${metadata}")`
     );
     formCheck.appendChild(metadataLink);
   }

--- a/src/components/mapComponent/controls/hierarchical-tree-layers.js
+++ b/src/components/mapComponent/controls/hierarchical-tree-layers.js
@@ -630,7 +630,7 @@ function renderLayer(layerData, parentElement, layerGroup) {
   // Add metadata link if available
   let metadata = layerData.metadata_id;
   if (metadata) {
-    let repositorio = metadata.length <= 6 ? DATAVERSE_URL : GEONETWORK_URL;
+    let repositorio = metadata.length == 6 ? DATAVERSE_URL : GEONETWORK_URL;
     const metadataLink = document.createElement("div");
     metadataLink.innerHTML = '<i class="fas fa-link"></i>';
     metadataLink.className = "card-link float-right";

--- a/src/components/server/geoserver/wms.js
+++ b/src/components/server/geoserver/wms.js
@@ -2,14 +2,9 @@ import {Tile as TileLayer} from 'ol/layer';
 import TileWMS from 'ol/source/TileWMS';
 import {GEOSERVER_URL,GEONETWORK_URL,DATAVERSE_URL} from '../url'
 // wms geoserver- load layer function
-export function wmsLayer(geoserverStore,geoserverLayer,geoserverName,visibility,idGeoNetwork){
-    let repositorio;
-    if (geoserverStore == 'visor' || geoserverStore == 'gefparamos') {
-        repositorio = DATAVERSE_URL;
-    }else{
-        repositorio = GEONETWORK_URL;
-    }
-    var geonetwork=(idGeoNetwork=!'' && idGeoNetwork)?repositorio+idGeoNetwork:'';
+export function wmsLayer(geoserverStore,geoserverLayer,geoserverName,visibility,metadataId){
+    let repositorio = metadataId.length <= 6 ? DATAVERSE_URL : GEONETWORK_URL;
+    var metadataLink=(metadataId=!'' && metadataId)?repositorio+metadataId:'';
     
     // Sanitize layer name to handle special characters and long names
     const sanitizedLayerName = geoserverLayer.trim();
@@ -38,7 +33,7 @@ export function wmsLayer(geoserverStore,geoserverLayer,geoserverName,visibility,
             name: geoserverLayer,
             geoserverName: geoserverLayer, // Store geoserver layer name for URL parameter matching
             displayName: geoserverName,    // Store display name
-            urldownload: geonetwork,
+            urldownload: metadataLink,
             extent: [-20037508.342789244, -20037508.342789244, 20037508.342789244, 20037508.342789244]
         });
         

--- a/src/components/server/geoserver/wms.js
+++ b/src/components/server/geoserver/wms.js
@@ -3,9 +3,12 @@ import TileWMS from 'ol/source/TileWMS';
 import {GEOSERVER_URL,GEONETWORK_URL,DATAVERSE_URL} from '../url'
 // wms geoserver- load layer function
 export function wmsLayer(geoserverStore,geoserverLayer,geoserverName,visibility,metadataId){
-    let repositorio = metadataId.length <= 6 ? DATAVERSE_URL : GEONETWORK_URL;
-    var metadataLink=(metadataId=!'' && metadataId)?repositorio+metadataId:'';
-    
+    var metadataLink = '';
+    if (metadataId=!'' && metadataId) {
+        let repositorio = metadataId.length == 6 ? DATAVERSE_URL : GEONETWORK_URL;
+        metadataLink = repositorio+metadataId;
+    } 
+
     // Sanitize layer name to handle special characters and long names
     const sanitizedLayerName = geoserverLayer.trim();
     


### PR DESCRIPTION
## 🛠️ Changes
Se elimina la url quemada a GeoNetwork para los links de las capas.
Se agrega un condicional para identificar cuando un id sea de 6 digitos (BioCultural) o mayor (GeoNetwork)
La validación de agrega también para los metadatos de la capa

## 📝 Associated issues
Part of LIB-582

## 🤔 Considerations
Se debe actualizar la base de datos para agregar los ids de las capas faltantes:
`UPDATE layers SET metadata_id='7UAZDX' WHERE nombre_geoserver='red_viveros';`
`UPDATE layers SET metadata_id='LPM4RE' WHERE nombre_geoserver='paramo' OR nombre_geoserver='municipio';`