### PR TITLE
Set correct pointer events for toast

### DIFF
--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -77,6 +77,11 @@ button, *:focus {
     position: absolute;
     right: 0px;
     bottom: 0px;
+    pointer-events: none;
+}
+
+.toast.show{
+    pointer-events: auto;
 }
 
 .close {


### PR DESCRIPTION
## 🛠️ Changes
Se agrega el atributo `pointer-events` para que el toast no interfiera con otros elementos mientras no esté habilitado

## 📝 Associated issues
Resolves LIB-757

