### PR TITLE
Optimize logos visualization in side bar

### DIFF
--- a/src/components/pageComponent/side-bar/close-sidebar.js
+++ b/src/components/pageComponent/side-bar/close-sidebar.js
@@ -10,6 +10,7 @@ export function closeSideBar(){
     $('.sideBarSpanActive').addClass('sideBarSpanNoActive').removeClass('sideBarSpanActive');
     $('#dropdown-catalogs').removeClass('active').addClass('nonactive')
     $('#tutorialstep2').removeClass('active');
+    $('.sideBarMiniLogo').removeClass('hidden');
 
     setTimeout(function(){updateSize()}, 100);
   }

--- a/src/components/pageComponent/side-bar/open-sidebar.js
+++ b/src/components/pageComponent/side-bar/open-sidebar.js
@@ -9,6 +9,7 @@ export var openSideBar=()=>{
     $('#closebtn').addClass('active');
     $('.centerLiIcons').removeClass('nonactive');
     $('.sideBarSpanNoActive').addClass('sideBarSpanActive').removeClass('sideBarSpanNoActive');
+    $('.sideBarMiniLogo').addClass('hidden');
     
     $('#tutorialstep2').addClass('active');
     // map resize when change view

--- a/src/components/pageComponent/side-bar/sidebar.scss
+++ b/src/components/pageComponent/side-bar/sidebar.scss
@@ -98,6 +98,10 @@
         font-weight: 400;
     }
 }
+
+.hidden{
+    display: none;
+}
 .sideBarSpanActive {
     display:inline-block;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -56,9 +56,11 @@
                             Infraestructura Institucional de Datos e Información
                         </div>
                     </a>
-                    <img id="logo_mini" src="" alt="Current project mini logo" width="46" height="auto" style="display: none;">
+                    <div class="sideBarMiniLogo">
+                        <img id="logo_mini" src="" alt="Current project mini logo" width="46" height="auto" style="display: none;">
+                    </div>
                     <div class="sideBarSpanNoActive">
-                        <img id="logo_full" src="" alt="Current project full logo" width="170" height="auto" style="display: none;">
+                        <img id="logo_full" src="" alt="Current project full logo" width="180" height="auto" style="display: none;">
                     </div>
                 </li>
             </ul>


### PR DESCRIPTION
## 🛠️ Changes
Se muestra el logo pequeño cuando el side bar está cerrado y se muestra el logo completo cuando el side bar está abierto.

## 📝 Associated issues
LIB-799
